### PR TITLE
feat: Add Copy Error Details button to error banners

### DIFF
--- a/GittyCat/ConfigWizard.swift
+++ b/GittyCat/ConfigWizard.swift
@@ -82,7 +82,17 @@ struct ConfigWizard: View {
             }
 
             if let err = lastError {
-                Text(err).foregroundColor(.red).font(.caption)
+                HStack {
+                    Text(err).font(.caption2).foregroundColor(.red)
+                    Spacer()
+                    Button("Copy Error Details") {
+                        let pasteboard = NSPasteboard.general
+                        pasteboard.clearContents()
+                        pasteboard.setString(err, forType: .string)
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.caption2)
+                }
             }
 
             HStack {

--- a/GittyCat/MainView.swift
+++ b/GittyCat/MainView.swift
@@ -20,7 +20,17 @@ struct MainView: View {
 
             Text(sync.lastStatus).font(.caption)
             if let err = sync.lastError {
-                Text(err).font(.caption2).foregroundColor(.red)
+                HStack {
+                    Text(err).font(.caption2).foregroundColor(.red)
+                    Spacer()
+                    Button("Copy Error Details") {
+                        let pasteboard = NSPasteboard.general
+                        pasteboard.clearContents()
+                        pasteboard.setString(err, forType: .string)
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.caption2)
+                }
             }
 
             Divider()


### PR DESCRIPTION
## Summary
Adds a 'Copy Error Details' button to error banners in both MainView and ConfigWizard.

## Changes
- Modified error display in `MainView.swift` to include copy button
- Modified error display in `ConfigWizard.swift` to include copy button
- Uses `NSPasteboard` to copy error text to macOS clipboard
- Button only appears when errors are present
- Maintains existing error styling and layout

## Issue
[#54](https://github.com/krushndayshmookh/GittyCat/issues/54#issuecomment-3394102532)