### PR TITLE
chore(build): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,9 @@ jobs:
             -archivePath ${{ env.ARCHIVE_PATH }} \
             MARKETING_VERSION=${{ github.ref_name }}
           
-          xcodebuild exportArchive \
+          xcodebuild archive \
             -archivePath ${{ env.ARCHIVE_PATH }} \
+            -exportArchive \
             -exportOptionsPlist export_options.plist \
             -exportPath ${{ env.EXPORT_PATH }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-12
 
     steps:
       - name: Delete old prerelease
@@ -35,6 +35,8 @@ jobs:
         run: echo "version=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Build
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
         run: |
           xcodebuild archive -project GittyCat.xcodeproj -scheme GittyCat -configuration Release -archivePath GittyCat.xcarchive MARKETING_VERSION=${{github.ref_name}}
           xcodebuild archive -archivePath GittyCat.xcarchive -exportArchive -exportOptionsPlist export_options.plist -exportPath .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ on:
     tags:
       - 'v*'
 
+env:
+  APP_NAME: GittyCat
+  PROJECT_FILE: GittyCat.xcodeproj
+  SCHEME: GittyCat
+  ARCHIVE_PATH: GittyCat.xcarchive
+  EXPORT_PATH: .
+  ZIP_NAME: GittyCat-${{ env.VERSION }}.zip
+  SIGNING_METHOD: adhoc # Set to 'adhoc' for free signing, 'developer' for proper signing + notarization
+
 jobs:
   build:
     runs-on: macos-15
@@ -28,23 +37,56 @@ jobs:
 
       - name: Set version for tag
         if: github.ref_type == 'tag'
-        run: echo "version=$(git describe --tags --match 'v*')" >> $GITHUB_ENV
+        run: echo "VERSION=$(git describe --tags --match 'v*')" >> $GITHUB_ENV
 
       - name: Set version for branch
         if: github.ref_type == 'branch'
-        run: echo "version=$(git describe --tags)" >> $GITHUB_ENV
+        run: echo "VERSION=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Build
         run: |
-          xcodebuild archive -project GittyCat.xcodeproj -scheme GittyCat -configuration Release -archivePath GittyCat.xcarchive MARKETING_VERSION=${{github.ref_name}}
-          xcodebuild archive -archivePath GittyCat.xcarchive -exportArchive -exportOptionsPlist export_options.plist -exportPath .
-          zip -r "GittyCat-${{env.version}}.zip" "GittyCat.app"
+          xcodebuild archive \
+            -project ${{ env.PROJECT_FILE }} \
+            -scheme ${{ env.SCHEME }} \
+            -configuration Release \
+            -archivePath ${{ env.ARCHIVE_PATH }} \
+            MARKETING_VERSION=${{ github.ref_name }}
+          
+          xcodebuild exportArchive \
+            -archivePath ${{ env.ARCHIVE_PATH }} \
+            -exportOptionsPlist export_options.plist \
+            -exportPath ${{ env.EXPORT_PATH }}
+
+      - name: Ad-hoc sign
+        if: env.SIGNING_METHOD == 'adhoc'
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: ${{ env.APP_NAME }}.app
+
+      - name: Prepare certificate
+        if: env.SIGNING_METHOD == 'developer'
+        run: echo "${{ secrets.APPLE_CERTIFICATE }}" | base64 --decode > cert.p12
+
+      - name: Sign and notarize
+        if: env.SIGNING_METHOD == 'developer'
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: ${{ env.APP_NAME }}.app
+          notarize: true
+          staple: true
+          p12_file: cert.p12
+          p12_password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          app_store_connect_api_issuer: ${{ secrets.APPLE_API_ISSUER }}
+          app_store_connect_api_key: ${{ secrets.APPLE_API_KEY }}
+
+      - name: Create zip
+        run: zip -r "${{ env.ZIP_NAME }}" "${{ env.APP_NAME }}.app"
 
       - name: Release
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v1
         with:
-          files: GittyCat-${{env.version}}.zip
+          files: ${{ env.ZIP_NAME }}
 
       - name: Prerelease
         if: github.ref_type == 'branch'
@@ -52,4 +94,4 @@ jobs:
         with:
           tag_name: prerelease
           prerelease: true
-          files: GittyCat-${{env.version}}.zip
+          files: ${{ env.ZIP_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ env:
   SCHEME: GittyCat
   ARCHIVE_PATH: GittyCat.xcarchive
   EXPORT_PATH: .
-  ZIP_NAME: GittyCat-${{ env.VERSION }}.zip
   SIGNING_METHOD: adhoc # Set to 'adhoc' for free signing, 'developer' for proper signing + notarization
 
 jobs:
@@ -37,11 +36,11 @@ jobs:
 
       - name: Set version for tag
         if: github.ref_type == 'tag'
-        run: echo "VERSION=$(git describe --tags --match 'v*')" >> $GITHUB_ENV
+        run: echo "ZIP_NAME=${{ env.APP_NAME }}-$(git describe --tags --match 'v*').zip" >> $GITHUB_ENV
 
       - name: Set version for branch
         if: github.ref_type == 'branch'
-        run: echo "VERSION=$(git describe --tags)" >> $GITHUB_ENV
+        run: echo "ZIP_NAME=${{ env.APP_NAME }}-$(git describe --tags).zip" >> $GITHUB_ENV
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - name: Delete old prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set version for tag
+      - name: Set ZIP name for tag
         if: github.ref_type == 'tag'
         run: echo "ZIP_NAME=${{ env.APP_NAME }}-$(git describe --tags --match 'v*').zip" >> $GITHUB_ENV
 
-      - name: Set version for branch
+      - name: Set ZIP name for branch
         if: github.ref_type == 'branch'
         run: echo "ZIP_NAME=${{ env.APP_NAME }}-$(git describe --tags).zip" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - name: Delete old prerelease
@@ -35,8 +35,6 @@ jobs:
         run: echo "version=$(git describe --tags)" >> $GITHUB_ENV
 
       - name: Build
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_14.1.app/Contents/Developer
         run: |
           xcodebuild archive -project GittyCat.xcodeproj -scheme GittyCat -configuration Release -archivePath GittyCat.xcarchive MARKETING_VERSION=${{github.ref_name}}
           xcodebuild archive -archivePath GittyCat.xcarchive -exportArchive -exportOptionsPlist export_options.plist -exportPath .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - name: Delete old prerelease
+        if: github.ref_type == 'branch'
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        with:
+          delete_release: true
+          tag_name: prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set version for tag
+        if: github.ref_type == 'tag'
+        run: echo "version=$(git describe --tags --match 'v*')" >> $GITHUB_ENV
+
+      - name: Set version for branch
+        if: github.ref_type == 'branch'
+        run: echo "version=$(git describe --tags)" >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          xcodebuild archive -project GittyCat.xcodeproj -scheme GittyCat -configuration Release -archivePath GittyCat.xcarchive MARKETING_VERSION=${{github.ref_name}}
+          xcodebuild archive -archivePath GittyCat.xcarchive -exportArchive -exportOptionsPlist export_options.plist -exportPath .
+          zip -r "GittyCat-${{env.version}}.zip" "GittyCat.app"
+
+      - name: Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: GittyCat-${{env.version}}.zip
+
+      - name: Prerelease
+        if: github.ref_type == 'branch'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: prerelease
+          prerelease: true
+          files: GittyCat-${{env.version}}.zip

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ open GittyCat.xcodeproj
 - [ ] Conflict resolution UI  
 - [ ] Auto .gitignore editor  
 - [ ] Secure bookmark access for Sandbox build  
-- [ ] Signed release on GitHub
+- [x] Signed release on GitHub
 
 ---
 

--- a/export_options.plist
+++ b/export_options.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>mac-application</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR introduces a release workflow based on [TomatoBar](https://github.com/ivoronin/TomatoBar)'s approach.
Closes https://github.com/krushndayshmookh/GittyCat/issues/42.

Manual tagging and pushing will trigger the workflow, which builds and publishes the app. For example:

```bash
git tag v0.0.4
git push origin v0.0.4
```

Example release:
https://github.com/junwen-k/GittyCat/releases/tag/v0.0.4