### PR TITLE
docs(README): add installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ It’s perfect for:
 
 ---
 
+## 📦 Installation
+
+Download the latest release [here](https://github.com/krushndayshmookh/GittyCat/releases/latest/) or install using Homebrew:
+
+```bash
+$ brew install --cask gittycat
+```
+
+If the app doesn't start, install using the `--no-quarantine` flag:
+
+```bash
+$ brew install --cask --no-quarantine gittycat
+```
+
+> 🐱 **Note:** GittyCat requires macOS 13 (Ventura) or later and needs access to your folders for syncing. You'll be prompted to grant permissions on first launch.
+
+---
+
 ## 🚀 Features
 
 - 🧠 **Smart Auto-Sync:** Periodic commits and pushes based on your schedule.  


### PR DESCRIPTION
Closes https://github.com/krushndayshmookh/GittyCat/issues/43.

I’ve tested a Homebrew cask file locally using my repository’s [v0.0.7 release](https://github.com/junwen-k/GittyCat/releases/tag/v0.0.7). The cask looked like this:

```rb
cask "gittycat" do
  version "0.0.7"
  sha256 "c3213f94e5c83449f18ce7e4fd6caf711528543e81c4de0f9a4b63defc045272"

  url "https://github.com/junwen-k/GittyCat/releases/download/v#{version}/GittyCat-v#{version}.zip"
  name "GittyCat"
  desc "Friendly macOS app that automatically commits and syncs local folders to GitHub"
  homepage "https://github.com/junwen-k/GittyCat"

  depends_on macos: ">= :ventura"

  app "GittyCat.app"

  zap trash: [
    "~/Library/Application Scripts/dev.rootkings.GittyCat",
    "~/Library/Application Support/GittyCat",
    "~/Library/Containers/dev.rootkings.GittyCat",
  ]
end
```

The installation worked, but only when using the `--no-quarantine` flag:

```zsh
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --no-quarantine gittycat
```

This is likely because the app is not yet notarized or signed.

We could improve https://github.com/krushndayshmookh/GittyCat/pull/68 by integrating something like [apple-code-sign-action](https://github.com/indygreg/apple-code-sign-action), which would handle code signing and notarization. This would eliminate the need for users to pass the `--no-quarantine` flag during installation.

The actual cask PR will be submitted directly to [homebrew-cask](https://github.com/Homebrew/homebrew-cask)
. Once https://github.com/krushndayshmookh/GittyCat/pull/68 is merged and the first release is published, we’ll need to update the cask to point to the official repository, update the `sha256`, and set the correct initial version.